### PR TITLE
added __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+from .WireIt import *
+WireIt().register()


### PR DESCRIPTION
I added an `__init__.py`, as suggested here: <https://github.com/xesscorp/WireIt/issues/11>.
Tested on Fedora 32 with KiCad 5.1.6-fc32.